### PR TITLE
refactor: use prefixed custom properties

### DIFF
--- a/demo/avatar-basic-demos.html
+++ b/demo/avatar-basic-demos.html
@@ -57,9 +57,9 @@
         <vaadin-avatar-group></vaadin-avatar-group>
         <style>
           vaadin-avatar-group {
-            --user-color-0: #b300d0;
-            --user-color-1: #00ae8f;
-            --user-color-2: #5c62f1;
+            --vaadin-user-color-0: #b300d0;
+            --vaadin-user-color-1: #00ae8f;
+            --vaadin-user-color-2: #5c62f1;
           }
         </style>
         <script>

--- a/src/vaadin-avatar.html
+++ b/src/vaadin-avatar.html
@@ -213,12 +213,13 @@ This program is available under Apache License Version 2.0, available at https:/
         __colorIndexChanged(index) {
           if (index != null) {
             this.setAttribute('has-color-index', '');
+            const color = `var(--vaadin-user-color-${index})`;
             if (window.ShadyCSS && !window.ShadyCSS.nativeCss) {
               window.ShadyCSS.styleSubtree(this, {
-                '--vaadin-avatar-border-color': `var(--user-color-${index})`
+                '--vaadin-avatar-border-color': color
               });
             } else {
-              this.style.setProperty('--vaadin-avatar-border-color', `var(--user-color-${index})`);
+              this.style.setProperty('--vaadin-avatar-border-color', color);
             }
           } else {
             this.removeAttribute('has-color-index');

--- a/test/avatar.html
+++ b/test/avatar.html
@@ -211,7 +211,7 @@
 
       describe('color index', () => {
         it('should set box-shadow based on color index', () => {
-          window.ShadyCSS.styleSubtree(avatar, {'--user-color-0': 'red'});
+          window.ShadyCSS.styleSubtree(avatar, {'--vaadin-user-color-0': 'red'});
           avatar.colorIndex = 0;
           const {boxShadow} = getComputedStyle(avatar, '::before');
           expect(['rgb(255, 0, 0)', 'red'].some(v => boxShadow.indexOf(v) > -1)).to.be.true;

--- a/test/visual/border.html
+++ b/test/visual/border.html
@@ -14,10 +14,10 @@
   <custom-style>
     <style>
       html {
-        --user-color-0: #B300D0;
-        --user-color-1: #00AE8F;
-        --user-color-2: #5C62F1;
-        --user-color-3: #D09600;
+        --vaadin-user-color-0: #B300D0;
+        --vaadin-user-color-1: #00AE8F;
+        --vaadin-user-color-2: #5C62F1;
+        --vaadin-user-color-3: #D09600;
       }
     </style>
   </custom-style>

--- a/test/visual/group-border.html
+++ b/test/visual/group-border.html
@@ -27,10 +27,10 @@
   <custom-style>
     <style>
       html {
-        --user-color-0: #B300D0;
-        --user-color-1: #00AE8F;
-        --user-color-2: #5C62F1;
-        --user-color-3: #D09600;
+        --vaadin-user-color-0: #B300D0;
+        --vaadin-user-color-1: #00AE8F;
+        --vaadin-user-color-2: #5C62F1;
+        --vaadin-user-color-3: #D09600;
       }
     </style>
   </custom-style>


### PR DESCRIPTION
Added `--vaadin` prefix to user color CSS custom properties.