### PR TITLE
feat: implement screen reader support

### DIFF
--- a/src/vaadin-avatar-group.html
+++ b/src/vaadin-avatar-group.html
@@ -53,13 +53,15 @@ This program is available under Apache License Version 2.0, available at https:/
         theme$="[[theme]]"
         on-click="_onOverflowClick"
         on-keydown="_onOverflowKeyDown"
+        role="button"
+        aria-haspopup="listbox"
       ></vaadin-avatar>
     </div>
     <vaadin-avatar-group-overlay id="overlay" opened="{{_opened}}" on-vaadin-overlay-close="_onVaadinOverlayClose">
       <template>
         <vaadin-avatar-group-list-box on-keydown="_onListKeyDown">
           <template is="dom-repeat" items="[[__computeExtraItems(items.*, max)]]">
-            <vaadin-item theme="avatar-group-item">
+            <vaadin-item theme="avatar-group-item" role="option">
               <vaadin-avatar
                 name="[[item.name]]"
                 abbr="[[item.abbr]]"
@@ -67,6 +69,7 @@ This program is available under Apache License Version 2.0, available at https:/
                 part="avatar"
                 theme$="[[theme]]"
                 tabindex="-1"
+                aria-hidden="true"
               ></vaadin-avatar>
               [[item.name]]
             </vaadin-item>
@@ -226,7 +229,11 @@ This program is available under Apache License Version 2.0, available at https:/
           if (opened) {
             if (!this._menuElement) {
               this._menuElement = this._overlayElement.content.querySelector('vaadin-avatar-group-list-box');
+              this._menuElement.setAttribute('role', 'listbox');
             }
+
+            const avatars = this._menuElement.querySelectorAll('vaadin-avatar');
+            avatars.forEach(avatar => avatar.removeAttribute('title'));
 
             this._menuElement.focus();
             this.__setPosition();
@@ -236,6 +243,7 @@ This program is available under Apache License Version 2.0, available at https:/
             this.$.overflow.setAttribute('focus-ring', '');
             window.removeEventListener('scroll', this.__boundSetPosition, true);
           }
+          this.$.overflow.setAttribute('aria-expanded', opened === true);
         }
 
         __setPosition() {

--- a/src/vaadin-avatar.html
+++ b/src/vaadin-avatar.html
@@ -184,6 +184,10 @@ This program is available under Apache License Version 2.0, available at https:/
             this.__setTitle(this.name);
           }
 
+          if (!this.hasAttribute('role')) {
+            this.setAttribute('role', 'img');
+          }
+
           if (!this.hasAttribute('tabindex')) {
             this.setAttribute('tabindex', '0');
           }

--- a/test/avatar-group.html
+++ b/test/avatar-group.html
@@ -288,6 +288,95 @@
           expect(items[2].colorIndex).to.equal(2);
         });
       });
+
+      describe('ARIA roles', () => {
+        let overlay, overflow;
+
+        beforeEach(async() => {
+          group.items = [
+            {abbr: 'PM'},
+            {name: 'Yuriy Yevstihnyeyev'},
+            {name: 'Serhii Kulykov'},
+            {name: 'Jens Jansson'},
+          ];
+          group.max = 2;
+          await nextRender(group);
+          overlay = group.$.overlay;
+          overflow = group.$.overflow;
+        });
+
+        afterEach(() => {
+          overlay.close();
+        });
+
+        it('should set role="image" on the user avatars', () => {
+          const items = group.shadowRoot.querySelectorAll('vaadin-avatar');
+          expect(items[0].getAttribute('role')).to.equal('img');
+          expect(items[1].getAttribute('role')).to.equal('img');
+        });
+
+        it('should set role="image" on the overflow avatar', () => {
+          expect(overflow.getAttribute('role')).to.equal('button');
+        });
+
+        it('should set aria-haspopup="listbox" on the overflow avatar', () => {
+          expect(overflow.getAttribute('aria-haspopup')).to.equal('listbox');
+        });
+
+        it('should set aria-expanded="false" on the overflow avatar', () => {
+          expect(overflow.getAttribute('aria-expanded')).to.equal('false');
+        });
+
+        it('should set aria-expanded="true" on the overflow avatar on open', done => {
+          overlay.addEventListener('vaadin-overlay-open', () => {
+            expect(overflow.getAttribute('aria-expanded')).to.equal('true');
+            done();
+          });
+          overflow.click();
+        });
+
+        it('should set role="listbox" on the overlay list-box', done => {
+          overlay.addEventListener('vaadin-overlay-open', () => {
+            const list = overlay.content.querySelector('vaadin-avatar-group-list-box');
+            expect(list.getAttribute('role')).to.equal('listbox');
+            done();
+          });
+          overflow.click();
+        });
+
+        it('should set role="option" on the overlay items', done => {
+          overlay.addEventListener('vaadin-overlay-open', () => {
+            const items = overlay.content.querySelectorAll('[theme="avatar-group-item"]');
+            items.forEach(item => {
+              expect(item.getAttribute('role')).to.equal('option');
+            });
+            done();
+          });
+          overflow.click();
+        });
+
+        it('should remove title from the overlay avatars', done => {
+          overlay.addEventListener('vaadin-overlay-open', () => {
+            const avatars = overlay.content.querySelectorAll('vaadin-avatar');
+            avatars.forEach(avatar => {
+              expect(avatar.hasAttribute('title')).to.equal(false);
+            });
+            done();
+          });
+          overflow.click();
+        });
+
+        it('should set aria-hidden="true" on the overlay avatars', done => {
+          overlay.addEventListener('vaadin-overlay-open', () => {
+            const avatars = overlay.content.querySelectorAll('vaadin-avatar');
+            avatars.forEach(avatar => {
+              expect(avatar.getAttribute('aria-hidden')).to.equal('true');
+            });
+            done();
+          });
+          overflow.click();
+        });
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
Closes #10 

Tested in VoiceOver on Safari & Chrome.

- `<vaadin-avatar>` is announced as image
- `+N` avatar in a group is announced as popup button
- overlay items are announced as `vaadin-select` items

Two tweaks are needed to avoid overlay items from being incorrectly announced:

-  using `aria-hidden` for the avatars in the overlay
- removing `title` attribute from those avatars.