### PR TITLE
feat: generate TypeScript definitions

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,6 @@
+export interface AvatarGroupItem {
+  name?: string;
+  abbr?: string;
+  img?: string;
+  colorIndex?: number;
+}

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,18 @@
+{
+  "excludeFiles": [
+    "gulpfile.js",
+    "wct.conf.js",
+    "index.html",
+    "src/vaadin-avatar-group-list-box.js",
+    "src/vaadin-avatar-group-overlay.js",
+    "src/vaadin-avatar-icons.js",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "./@types/interfaces": [
+      "AvatarGroupItem"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,12 @@
+module.exports = {
+  files: [
+    'vaadin-avatar.js',
+    'vaadin-avatar-group.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "theme"
   ],

--- a/src/vaadin-avatar-group.html
+++ b/src/vaadin-avatar-group.html
@@ -112,6 +112,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * An array containing the items which will be stamped as avatars
+             * @type {!Array<!AvatarGroupItem> | undefined}
              */
             items: {
               type: Array
@@ -126,11 +127,13 @@ This program is available under Apache License Version 2.0, available at https:/
               type: Number
             },
 
+            /** @private */
             __maxReached: {
               type: Boolean,
               computed: '__computeMaxReached(items.length, max)'
             },
 
+            /** @private */
             _opened: {
               type: Boolean,
               observer: '__openedChanged',
@@ -143,6 +146,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return ['__computeMoreTitle(items.length, max)'];
         }
 
+        /** @protected */
         ready() {
           super.ready();
 
@@ -153,6 +157,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._overlayElement = this.shadowRoot.querySelector('vaadin-avatar-group-overlay');
         }
 
+        /** @private */
         _onOverflowClick(e) {
           e.stopPropagation();
           if (this._opened) {
@@ -162,6 +167,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _onOverflowKeyDown(e) {
           if (!this._opened) {
             if (/^(Enter|SpaceBar|\s)$/.test(e.key)) {
@@ -171,40 +177,48 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _onListKeyDown(event) {
           if (event.key === 'Escape' || event.key === 'Esc' || /^(Tab)$/.test(event.key)) {
             this._opened = false;
           }
         }
 
+        /** @private */
         _onResize() {
           this.__setPosition();
         }
 
+        /** @private */
         _onVaadinOverlayClose(e) {
           if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().indexOf(this) !== -1) {
             e.preventDefault();
           }
         }
 
+        /** @private */
         __computeItems(arr, max) {
           const items = arr.base || [];
           return max != null ? items.slice(0, max) : items;
         }
 
+        /** @private */
         __computeExtraItems(arr, max) {
           const items = arr.base || [];
           return max != null ? items.slice(max) : items;
         }
 
+        /** @private */
         __computeMaxReached(items, max) {
           return max != null && items > max;
         }
 
+        /** @private */
         __computeMore(items, max) {
           return `+${items - max}`;
         }
 
+        /** @private */
         __computeMoreTitle(items, max) {
           if (max == null) {
             return;
@@ -218,10 +232,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.$.overflow.setAttribute('title', result.join('\n'));
         }
 
-        __itemsChanged(items) {
-          this.__updateOffset();
-        }
-
+        /** @private */
         __openedChanged(opened, wasOpened) {
           if (opened) {
             if (!this._menuElement) {
@@ -238,6 +249,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         __setPosition() {
           if (!this._opened) {
             return;

--- a/src/vaadin-avatar.html
+++ b/src/vaadin-avatar.html
@@ -174,6 +174,7 @@ This program is available under Apache License Version 2.0, available at https:/
           ];
         }
 
+        /** @protected */
         ready() {
           super.ready();
 
@@ -189,15 +190,16 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           this.addEventListener('focusin', () => {
-            this._setFocused(true);
+            this.__setFocused(true);
           });
 
           this.addEventListener('focusout', () => {
-            this._setFocused(false);
+            this.__setFocused(false);
           });
         }
 
-        _setFocused(focused) {
+        /** @private */
+        __setFocused(focused) {
           if (focused) {
             this.setAttribute('focused', '');
 
@@ -210,6 +212,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         __colorIndexChanged(index) {
           if (index != null) {
             this.setAttribute('has-color-index', '');
@@ -226,6 +229,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         __imgOrAbbrOrNameChanged(img, abbr, name) {
           this.__updateVisibility();
 
@@ -245,12 +249,14 @@ This program is available under Apache License Version 2.0, available at https:/
           this.__setTitle(name);
         }
 
+        /** @private */
         __updateVisibility() {
           this.__imgVisible = !!this.img;
           this.__abbrVisible = !this.img && !!this.abbr;
           this.__iconVisible = !this.img && !this.abbr;
         }
 
+        /** @private */
         __setTitle(title) {
           if (title) {
             this.setAttribute('title', title);


### PR DESCRIPTION
Fixes #11 

Generated TS definition files look like this:

### `vaadin-avatar.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class AvatarElement extends
  ElementMixin(
  ThemableMixin(
  PolymerElement)) {
  img: string|null|undefined;
  abbr: string|null|undefined;
  name: string|null|undefined;
  colorIndex: number|null|undefined;
  ready(): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-avatar": AvatarElement;
  }
}

export {AvatarElement};
```

### `vaadin-avatar-group.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {IronResizableBehavior} from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';

declare class AvatarGroupElement extends
  ElementMixin(
  ThemableMixin(
  PolymerElement)) {
  items: AvatarGroupItem[]|undefined;
  max: number|null|undefined;
  ready(): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-avatar-group": AvatarGroupElement;
  }
}

export {AvatarGroupElement};

import {AvatarGroupItem} from '../@types/interfaces';
```