### PR TITLE
fix: only restore focus-ring if present

### DIFF
--- a/src/vaadin-avatar-group.html
+++ b/src/vaadin-avatar-group.html
@@ -266,6 +266,8 @@ This program is available under Apache License Version 2.0, available at https:/
               this._menuElement.setAttribute('role', 'listbox');
             }
 
+            this._openedWithFocusRing = this.$.overflow.hasAttribute('focus-ring');
+
             const avatars = this._menuElement.querySelectorAll('vaadin-avatar');
             avatars.forEach(avatar => avatar.removeAttribute('title'));
 
@@ -274,7 +276,9 @@ This program is available under Apache License Version 2.0, available at https:/
             window.addEventListener('scroll', this.__boundSetPosition, true);
           } else if (wasOpened) {
             this.$.overflow.focus();
-            this.$.overflow.setAttribute('focus-ring', '');
+            if (this._openedWithFocusRing) {
+              this.$.overflow.setAttribute('focus-ring', '');
+            }
             window.removeEventListener('scroll', this.__boundSetPosition, true);
           }
           this.$.overflow.setAttribute('aria-expanded', opened === true);

--- a/src/vaadin-avatar.html
+++ b/src/vaadin-avatar.html
@@ -82,12 +82,12 @@ This program is available under Apache License Version 2.0, available at https:/
       // event since the last mousedown event.
       let keyboardActive = false;
 
-      // Listen for top-level keydown and mousedown events.
+      // Listen for top-level Tab keydown and mousedown events.
       // Use capture phase so we detect events even if they're handled.
       window.addEventListener(
         'keydown',
-        () => {
-          keyboardActive = true;
+        (e) => {
+          keyboardActive = e.keyCode === 9;
         },
         true
       );

--- a/test/avatar-group.html
+++ b/test/avatar-group.html
@@ -258,7 +258,7 @@
           overflow.click();
         });
 
-        it('should set focus-ring attribute on overlay close', done => {
+        it('should restore focus-ring attribute on overlay close', done => {
           overlay.addEventListener('vaadin-overlay-open', () => {
             overflow.click();
 
@@ -267,6 +267,22 @@
               done();
             });
           });
+
+          overflow.setAttribute('focus-ring', '');
+          overflow.click();
+        });
+
+        it('should not restore focus-ring attribute on close if not set', done => {
+          overlay.addEventListener('vaadin-overlay-open', () => {
+            const list = overlay.content.querySelector('vaadin-avatar-group-list-box');
+            MockInteractions.keyDownOn(list, 27, [], 'Escape');
+
+            Polymer.RenderStatus.afterNextRender(overlay, () => {
+              expect(overflow.hasAttribute('focus-ring')).to.be.false;
+              done();
+            });
+          });
+
           overflow.click();
         });
       });


### PR DESCRIPTION
Fixes #41 

Aligned implementation with `vaadin-select`.