### PR TITLE
fix: set title with both image and name

### DIFF
--- a/src/vaadin-avatar.html
+++ b/src/vaadin-avatar.html
@@ -236,7 +236,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.__updateVisibility();
 
           if (abbr && abbr !== this.__generatedAbbr) {
-            this.__setTitle(abbr);
+            this.__setTitle(name ? `${name} (${abbr})` : abbr);
             return;
           }
 

--- a/src/vaadin-avatar.html
+++ b/src/vaadin-avatar.html
@@ -235,10 +235,8 @@ This program is available under Apache License Version 2.0, available at https:/
         __imgOrAbbrOrNameChanged(img, abbr, name) {
           this.__updateVisibility();
 
-          if (img || (abbr && abbr !== this.__generatedAbbr)) {
-            if (abbr) {
-              this.__setTitle(abbr);
-            }
+          if (abbr && abbr !== this.__generatedAbbr) {
+            this.__setTitle(abbr);
             return;
           }
 

--- a/test/avatar.html
+++ b/test/avatar.html
@@ -155,6 +155,12 @@
             avatar.abbr = 'FB';
             expect(avatar.getAttribute('title')).to.equal('FB');
           });
+
+          it('should set title when both "abbr" and "name" are set', function() {
+            avatar.abbr = 'GG';
+            avatar.name = 'Well played';
+            expect(avatar.getAttribute('title')).to.equal('Well played (GG)');
+          });
         });
 
         describe('"name" property', function() {

--- a/test/avatar.html
+++ b/test/avatar.html
@@ -81,6 +81,12 @@
             avatar.img = imgSrc;
             expect(abbrElement.hasAttribute('hidden')).to.be.true;
           });
+
+          it('should set title when both "img" and "name" are set', function() {
+            avatar.img = imgSrc;
+            avatar.name = 'Foo Bar';
+            expect(avatar.getAttribute('title')).to.equal('Foo Bar');
+          });
         });
 
         describe('"abbr" property', function() {


### PR DESCRIPTION
Fixes #50 
Fixes #46 

Looks like the original code was trying to avoid generating `abbr` in case if `img` is set.