### PR TITLE
chore: reset -webkit-tap-highlight-color [skip ci]

### DIFF
--- a/theme/lumo/vaadin-avatar-styles.html
+++ b/theme/lumo/vaadin-avatar-styles.html
@@ -16,6 +16,7 @@
         outline: none;
         cursor: default;
         user-select: none;
+        -webkit-tap-highlight-color: transparent;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
       }

--- a/theme/material/vaadin-avatar-styles.html
+++ b/theme/material/vaadin-avatar-styles.html
@@ -12,6 +12,7 @@
         cursor: default;
         outline: none;
         user-select: none;
+        -webkit-tap-highlight-color: transparent;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
       }


### PR DESCRIPTION
Aligned with `vaadin-button` and other clickable components.