### PR TITLE
Fix SVG broken by magi version, refactor styles

### DIFF
--- a/src/vaadin-avatar-group.js
+++ b/src/vaadin-avatar-group.js
@@ -77,8 +77,8 @@ class AvatarGroupElement extends ElementMixin(ThemableMixin(mixinBehaviors([Iron
         }
 
         [part='avatar']:not(:first-child) {
-          -webkit-mask-image: url('data:image/svg+xml;utf8,<svg viewBox=%2.0.1 300 300%22 fill=%22none%22 xmlns=%22http://www.w3.org/2000/svg%22><path fill-rule=%22evenodd%22 clip-rule=%22evenodd%22 d=%22M300 0H0V300H300V0ZM150 200C177.614 200 200 177.614 200 150C200 122.386 177.614 100 150 100C122.386 100 100 122.386 100 150C100 177.614 122.386 200 150 200Z%22 fill=%22black%22/></svg>');
-          mask-image: url('data:image/svg+xml;utf8,<svg viewBox=%2.0.1 300 300%22 fill=%22none%22 xmlns=%22http://www.w3.org/2000/svg%22><path fill-rule=%22evenodd%22 clip-rule=%22evenodd%22 d=%22M300 0H0V300H300V0ZM150 200C177.614 200 200 177.614 200 150C200 122.386 177.614 100 150 100C122.386 100 100 122.386 100 150C100 177.614 122.386 200 150 200Z%22 fill=%22black%22/></svg>');
+          -webkit-mask-image: url('data:image/svg+xml;utf8,<svg viewBox=%220 0 300 300%22 fill=%22none%22 xmlns=%22http://www.w3.org/2000/svg%22><path fill-rule=%22evenodd%22 clip-rule=%22evenodd%22 d=%22M300 0H0V300H300V0ZM150 200C177.614 200 200 177.614 200 150C200 122.386 177.614 100 150 100C122.386 100 100 122.386 100 150C100 177.614 122.386 200 150 200Z%22 fill=%22black%22/></svg>');
+          mask-image: url('data:image/svg+xml;utf8,<svg viewBox=%220 0 300 300%22 fill=%22none%22 xmlns=%22http://www.w3.org/2000/svg%22><path fill-rule=%22evenodd%22 clip-rule=%22evenodd%22 d=%22M300 0H0V300H300V0ZM150 200C177.614 200 200 177.614 200 150C200 122.386 177.614 100 150 100C122.386 100 100 122.386 100 150C100 177.614 122.386 200 150 200Z%22 fill=%22black%22/></svg>');
           -webkit-mask-size: calc(
             300% + var(--vaadin-avatar-group-overlap-border) * 6 - var(--vaadin-avatar-outline-width) * 6
           );

--- a/theme/lumo/vaadin-avatar-group-styles.js
+++ b/theme/lumo/vaadin-avatar-group-styles.js
@@ -11,42 +11,36 @@ registerStyles(
       --_lumo-avatar-group-offset: var(--lumo-size-m);
     }
 
-    [part='avatar']:not([dir='rtl']):not(:first-child) {
-      -webkit-mask-position: calc(50% - var(--_lumo-avatar-group-offset) + var(--vaadin-avatar-group-overlap));
-      mask-position: calc(50% - var(--_lumo-avatar-group-offset) + var(--vaadin-avatar-group-overlap));
+    :host([theme~='small']) {
+      --vaadin-avatar-size: var(--lumo-size-s);
     }
 
-    [part='avatar'][dir='rtl']:not(:first-child) {
-      -webkit-mask-position: calc(
-        50% + var(--_lumo-avatar-group-offset) - var(--vaadin-avatar-group-overlap) + var(--vaadin-avatar-outline-width)
-      );
-      mask-position: calc(
-        50% + var(--_lumo-avatar-group-offset) - var(--vaadin-avatar-group-overlap) + var(--vaadin-avatar-outline-width)
-      );
+    :host([theme~='xsmall']) {
+      --vaadin-avatar-size: var(--lumo-size-xs);
     }
 
     :host([theme~='xlarge']) {
       --vaadin-avatar-group-overlap: 12px;
       --vaadin-avatar-group-overlap-border: 3px;
-      --_lumo-avatar-group-offset: var(--lumo-size-xl);
+      --vaadin-avatar-size: var(--lumo-size-xl);
     }
 
     :host([theme~='large']) {
       --vaadin-avatar-group-overlap: 10px;
       --vaadin-avatar-group-overlap-border: 3px;
-      --_lumo-avatar-group-offset: var(--lumo-size-l);
+      --vaadin-avatar-size: var(--lumo-size-xl);
     }
 
     :host([theme~='small']) {
       --vaadin-avatar-group-overlap: 6px;
       --vaadin-avatar-group-overlap-border: 2px;
-      --_lumo-avatar-group-offset: var(--lumo-size-s);
+      --vaadin-avatar-size: var(--lumo-size-s);
     }
 
     :host([theme~='xsmall']) {
       --vaadin-avatar-group-overlap: 4px;
       --vaadin-avatar-group-overlap-border: 2px;
-      --_lumo-avatar-group-offset: var(--lumo-size-xs);
+      --vaadin-avatar-size: var(--lumo-size-xs);
     }
   `,
   { moduleId: 'lumo-avatar-group' }

--- a/theme/lumo/vaadin-avatar-styles.js
+++ b/theme/lumo/vaadin-avatar-styles.js
@@ -57,23 +57,19 @@ registerStyles(
     }
 
     :host([theme~='xlarge']) {
-      width: var(--lumo-size-xl);
-      height: var(--lumo-size-xl);
+      --vaadin-avatar-size: var(--lumo-size-xl);
     }
 
     :host([theme~='large']) {
-      width: var(--lumo-size-l);
-      height: var(--lumo-size-l);
+      --vaadin-avatar-size: var(--lumo-size-l);
     }
 
     :host([theme~='small']) {
-      width: var(--lumo-size-s);
-      height: var(--lumo-size-s);
+      --vaadin-avatar-size: var(--lumo-size-s);
     }
 
     :host([theme~='xsmall']) {
-      width: var(--lumo-size-xs);
-      height: var(--lumo-size-xs);
+      --vaadin-avatar-size: var(--lumo-size-xs);
     }
   `,
   { moduleId: 'lumo-avatar' }


### PR DESCRIPTION
The `2.0.1` version is badly broken because of [version update commit](https://github.com/vaadin/vaadin-avatar/commit/dea89381995e5bfc918d86463fa9366e3b3cbc0e).

This is a hotfix which also updates styles missed in #107 